### PR TITLE
WindowsApp.lib only should be included in Windows

### DIFF
--- a/src/AvaloniaCoreRTDemo.csproj
+++ b/src/AvaloniaCoreRTDemo.csproj
@@ -16,7 +16,7 @@
 	<IlcDisableUnhandledExceptionExperience>false</IlcDisableUnhandledExceptionExperience>
   </PropertyGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('win'))">
 	<!-- Instruct CoreRT to use this native dependency, required to build Avalonia. This library comes from the Windows SDK. -->
     <NativeLibrary Include="WindowsApp.lib" />
   </ItemGroup>


### PR DESCRIPTION
The csproj file isn't checking the target platform a prior to include WindowsApp.lib, which should only included when the target os Windows.