### PR TITLE
Lastest Packages Update

### DIFF
--- a/src/AvaloniaCoreRTDemo.csproj
+++ b/src/AvaloniaCoreRTDemo.csproj
@@ -32,12 +32,12 @@
     <EmbeddedResource Include="windows.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.10" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.10" />
+    <PackageReference Include="Avalonia" Version="0.9.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.11" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.11" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
     <!-- This is a hack. Avalonia 0.9.10 depends on a version of System.Reactive prior 4.4.1, which contains a critical fix for building with CoreRT -->
-    <PackageReference Include="System.Reactive" Version="4.4.1" />
+    <PackageReference Include="System.Reactive" Version="5.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Avalonia relies heavily on reflection. Describe types reflected upon here. -->


### PR DESCRIPTION
System.Reactive is updated to version 5.0, consistent with NET 5.0, additionally AvaloniaUI is updated to version 0.9.11 since this is the last version compatible with NativeAOT (formerly CoreRT)