### PR TITLE
Upgrade Avalonia UI Version

### DIFF
--- a/src/AboutWindowViewModel.cs
+++ b/src/AboutWindowViewModel.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Avalonia.Media.Imaging;
 using ReactiveUI;
+
 namespace AvaloniaCoreRTDemo
 {
     public class AboutWindowViewModel : ReactiveObject

--- a/src/AvaloniaCoreRTDemo.csproj
+++ b/src/AvaloniaCoreRTDemo.csproj
@@ -13,7 +13,7 @@
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcDisableUnhandledExceptionExperience>true</IlcDisableUnhandledExceptionExperience>
   </PropertyGroup>
-  
+    
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('win'))">
     <!-- Instruct CoreRT to use this native dependency, required to build Avalonia. This library comes from the Windows SDK. -->
     <NativeLibrary Include="WindowsApp.lib" />
@@ -32,12 +32,10 @@
     <EmbeddedResource Include="windows.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.11" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.11" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.11" />
+    <PackageReference Include="Avalonia" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
-    <!-- This is a hack. Avalonia 0.9.10 depends on a version of System.Reactive prior 4.4.1, which contains a critical fix for building with CoreRT -->
-    <PackageReference Include="System.Reactive" Version="5.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Avalonia relies heavily on reflection. Describe types reflected upon here. -->

--- a/src/AvaloniaCoreRTDemo.csproj
+++ b/src/AvaloniaCoreRTDemo.csproj
@@ -8,7 +8,8 @@
   
   <PropertyGroup>
     <!-- these can help when debugging weird exceptions especially when reflection is involved. See https://github.com/dotnet/corert/blob/master/Documentation/using-corert/optimizing-corert.md -->  
-    <RootAllApplicationAssemblies>false</RootAllApplicationAssemblies>
+    <!--RootAllApplicationAssemblies: False -> TrimMode:link See https://github.com/dotnet/runtimelab/issues/597 and https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/optimizing.md -->
+	<TrimMode>link</TrimMode>
     <IlcGenerateCompleteTypeMetadata>false</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcDisableUnhandledExceptionExperience>true</IlcDisableUnhandledExceptionExperience>

--- a/src/MainWindowViewModel.cs
+++ b/src/MainWindowViewModel.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Media.Imaging;
+﻿using Avalonia.Media.Imaging;
 using ReactiveUI;
 using System;
 using System.Reactive;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Logging.Serilog;
+﻿using Avalonia;
 
 namespace AvaloniaCoreRTDemo
 {
@@ -18,6 +14,6 @@ namespace AvaloniaCoreRTDemo
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
-                .LogToDebug();
+                .LogToTrace();
     }
 }


### PR DESCRIPTION
Avalonia UI package upgrade to 0.10.0, System.Reactive isn't longer required by now.

Note:
From Microsoft.DotNet.ILCompiler version 6.0.0-alpha.1.21072.1 compilation takes a long time and reaches high ram consumes, additionally it generates warnings on System.Reactive following methods:
[System.Reactive]System.Reactive.Concurrency.CatchScheduler`1+CatchSchedulerPeriodic+PeriodicallyScheduledWorkItem`1<System.__Canon,System.ValueTuple`2<System.__Canon,System.__Canon>>.Tick(ValueTuple`2<__Canon,__Canon>)
[System.Reactive]System.Reactive.Concurrency.CatchScheduler`1+CatchSchedulerPeriodic+PeriodicallyScheduledWorkItem`1<System.__Canon,System.__Canon>.Tick(__Canon)

The warning says: "Method will always throw because: Invalid IL or CLR metadata".

However, it successfully compiles on Windows and Linux (WSL).