### PR TITLE
Fix macOS build

### DIFF
--- a/test.command
+++ b/test.command
@@ -6,8 +6,5 @@ fi
 rm -f src/packages.lock.json 
 dotnet publish -r osx-x64 -c release /p:RestoreLockedMode=true -t:BundleApp /p:TrimLink=true --self-contained 
 rm -rf src/bin/x64/Release/net7.0/osx-x64/publish/Assets/
-strip src/bin/x64/Release/net7.0/osx-x64/publish/AvaloniaCoreRTDemo.app/Contents/MacOS/AvaloniaCoreRTDemo 
 rm -rf src/bin/x64/Release/net7.0/osx-x64/publish/AvaloniaCoreRTDemo.app/Contents/MacOS/Assets/
-rm src/bin/x64/Release/net7.0/osx-x64/publish/AvaloniaCoreRTDemo.app/Contents/MacOS/AvaloniaCoreRTDemo.runtimeconfig.json 
-rm src/bin/x64/Release/net7.0/osx-x64/publish/AvaloniaCoreRTDemo.app/Contents/MacOS/AvaloniaCoreRTDemo.pdb 
-rm src/bin/x64/Release/net7.0/osx-x64/publish/AvaloniaCoreRTDemo.app/Contents/MacOS/AvaloniaCoreRTDemo.deps.json 
+rm src/bin/x64/Release/net7.0/osx-x64/publish/AvaloniaCoreRTDemo.app/Contents/MacOS/AvaloniaCoreRTDemo.dwarf


### PR DESCRIPTION
On macOS building, the output .app folder does not contain runtime configuration json files anymore. With StripSymbols, our debugging symbols are created in a .dwarf, not a .pdb.

* The output macOS binary still can't be stripped of all.
* We may need to create a fix for an issue in the app menu item on macOS (this item is only displayed on macOS with the app name).